### PR TITLE
Update bundler to 2.6.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,4 +282,4 @@ DEPENDENCIES
   jekyll-seo-tag (~> 2.5)
 
 BUNDLED WITH
-   2.4.10
+   2.6.7


### PR DESCRIPTION
## Summary
• Update bundler version from 2.4.10 to 2.6.7 in Gemfile.lock for improved security and compatibility

## Test plan
- [x] Verify Jekyll site builds successfully
- [x] Check that all gem dependencies resolve correctly
- [x] Confirm no breaking changes in bundler functionality

🤖 Generated with [Claude Code](https://claude.ai/code)